### PR TITLE
Default constructor and begin() method added.  Closes Issue #11

### DIFF
--- a/src/ResponsiveAnalogRead.cpp
+++ b/src/ResponsiveAnalogRead.cpp
@@ -3,6 +3,7 @@
  * Arduino library for eliminating noise in analogRead inputs without decreasing responsiveness
  *
  * Copyright (c) 2016 Damien Clarke
+ * THIS VERSION MODIFIED BY KATHRYN SCHAFFER
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +27,13 @@
 #include <Arduino.h>
 #include "ResponsiveAnalogRead.h"
 
+
+ResponsiveAnalogRead::ResponsiveAnalogRead(){
+    //do nothing - all actual configuration is done in setup function
+}
+
+
+
 ResponsiveAnalogRead::ResponsiveAnalogRead(int pin, bool sleepEnable, float snapMultiplier)
 {
   pinMode(pin, INPUT ); // ensure button pin is an input
@@ -35,6 +43,19 @@ ResponsiveAnalogRead::ResponsiveAnalogRead(int pin, bool sleepEnable, float snap
   this->sleepEnable = sleepEnable;
   setSnapMultiplier(snapMultiplier);
 }
+
+
+void ResponsiveAnalogRead::setup(int pin, bool sleepEnable, float snapMultiplier){
+    pinMode(pin, INPUT ); // ensure button pin is an input
+    digitalWrite(pin, LOW ); // ensure pullup is off on button pin
+    
+    this->pin = pin;
+    this->sleepEnable = sleepEnable;
+    setSnapMultiplier(snapMultiplier);
+    
+    
+}
+
 
 void ResponsiveAnalogRead::update()
 {

--- a/src/ResponsiveAnalogRead.cpp
+++ b/src/ResponsiveAnalogRead.cpp
@@ -3,7 +3,6 @@
  * Arduino library for eliminating noise in analogRead inputs without decreasing responsiveness
  *
  * Copyright (c) 2016 Damien Clarke
- * THIS VERSION MODIFIED BY KATHRYN SCHAFFER
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,9 +28,8 @@
 
 
 ResponsiveAnalogRead::ResponsiveAnalogRead(){
-    //do nothing - all actual configuration is done in setup function
+    //do nothing - all actual configuration is done in begin() function
 }
-
 
 
 ResponsiveAnalogRead::ResponsiveAnalogRead(int pin, bool sleepEnable, float snapMultiplier)
@@ -45,7 +43,7 @@ ResponsiveAnalogRead::ResponsiveAnalogRead(int pin, bool sleepEnable, float snap
 }
 
 
-void ResponsiveAnalogRead::setup(int pin, bool sleepEnable, float snapMultiplier){
+void ResponsiveAnalogRead::begin(int pin, bool sleepEnable, float snapMultiplier){
     pinMode(pin, INPUT ); // ensure button pin is an input
     digitalWrite(pin, LOW ); // ensure pullup is off on button pin
     

--- a/src/ResponsiveAnalogRead.h
+++ b/src/ResponsiveAnalogRead.h
@@ -3,7 +3,6 @@
  * Arduino library for eliminating noise in analogRead inputs without decreasing responsiveness
  *
  * Copyright (c) 2016 Damien Clarke
- * THIS VERSION MODIFIED BY KATHRYN SCHAFFER
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,10 +39,10 @@ class ResponsiveAnalogRead
     //   increase this to lessen the amount of easing (such as 0.1) and make the responsive values more responsive
     //   but doing so may cause more noise to seep through if sleep is not enabled
     
-    ResponsiveAnalogRead();  //added a default constructor to enable use as a member variable in a class
+    ResponsiveAnalogRead();  //default constructor must be followed by call to begin function
     ResponsiveAnalogRead(int pin, bool sleepEnable, float snapMultiplier = 0.01);
 
-    void setup(int pin, bool sleepEnable, float snapMultiplier = 0.01);  //setup replaces the original constructor
+    void begin(int pin, bool sleepEnable, float snapMultiplier = 0.01);  // use with default constructor to initialize 
     
     inline int getValue() { return responsiveValue; } // get the responsive value from last update
     inline int getRawValue() { return rawValue; } // get the raw analogRead() value from last update

--- a/src/ResponsiveAnalogRead.h
+++ b/src/ResponsiveAnalogRead.h
@@ -3,6 +3,7 @@
  * Arduino library for eliminating noise in analogRead inputs without decreasing responsiveness
  *
  * Copyright (c) 2016 Damien Clarke
+ * THIS VERSION MODIFIED BY KATHRYN SCHAFFER
  * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,8 +40,11 @@ class ResponsiveAnalogRead
     //   increase this to lessen the amount of easing (such as 0.1) and make the responsive values more responsive
     //   but doing so may cause more noise to seep through if sleep is not enabled
     
+    ResponsiveAnalogRead();  //added a default constructor to enable use as a member variable in a class
     ResponsiveAnalogRead(int pin, bool sleepEnable, float snapMultiplier = 0.01);
 
+    void setup(int pin, bool sleepEnable, float snapMultiplier = 0.01);  //setup replaces the original constructor
+    
     inline int getValue() { return responsiveValue; } // get the responsive value from last update
     inline int getRawValue() { return rawValue; } // get the raw analogRead() value from last update
     inline bool hasChanged() { return responsiveValueHasChanged; } // returns true if the responsive value has changed during the last update


### PR DESCRIPTION
This is a proposed temporary update to the library, providing a default constructor + begin() method for immediate use, pending more extensive API upgrades by the library author.