### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,15 +11,15 @@ ResponsiveAnalogRead	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-getValue					KEYWORD2
-getRawValue					KEYWORD2
-hasChanged					KEYWORD2
-update						KEYWORD2
-setSnapMultiplier			KEYWORD2
-enableSleep					KEYWORD2
-disableSleep				KEYWORD2
-isSleeping   				KEYWORD2
-setActivityThreshold	    KEYWORD2
-setAnalogResolution			KEYWORD2
-enableEdgeSnap    KEYWORD2
-begin    KEYWORD2
+getValue	KEYWORD2
+getRawValue	KEYWORD2
+hasChanged	KEYWORD2
+update	KEYWORD2
+setSnapMultiplier	KEYWORD2
+enableSleep	KEYWORD2
+disableSleep	KEYWORD2
+isSleeping	KEYWORD2
+setActivityThreshold	KEYWORD2
+setAnalogResolution	KEYWORD2
+enableEdgeSnap	KEYWORD2
+begin	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords