### PR TITLE
Release/fix raw value

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ResponsiveAnalogRead
-![ResponsiveAnalogRead](http://damienclarke.me/content/1-code/3-responsive-analog-read/thumbnail.jpg)
+
+![ResponsiveAnalogRead](https://user-images.githubusercontent.com/345320/50956817-c4631a80-1510-11e9-806a-27583707ca91.jpg)
 
 ResponsiveAnalogRead is an Arduino library for eliminating noise in analogRead inputs without decreasing responsiveness. It sets out to achieve the following:
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,15 +11,15 @@ ResponsiveAnalogRead	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-getValue					KEYWORD2
-getRawValue					KEYWORD2
-hasChanged					KEYWORD2
-update						KEYWORD2
-setSnapMultiplier			KEYWORD2
-enableSleep					KEYWORD2
-disableSleep				KEYWORD2
-isSleeping   				KEYWORD2
-setActivityThreshold	    KEYWORD2
-setAnalogResolution			KEYWORD2
-enableEdgeSnap    KEYWORD2
-begin    KEYWORD2
+getValue	KEYWORD2
+getRawValue	KEYWORD2
+hasChanged	KEYWORD2
+update	KEYWORD2
+setSnapMultiplier	KEYWORD2
+enableSleep	KEYWORD2
+disableSleep	KEYWORD2
+isSleeping	KEYWORD2
+setActivityThreshold	KEYWORD2
+setAnalogResolution	KEYWORD2
+enableEdgeSnap	KEYWORD2
+begin	KEYWORD2

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ResponsiveAnalogRead
-version=1.2.0
+version=1.2.1
 author=Damien Clarke <dxinteractive@gmail.com>
 maintainer=Damien Clarke <dxinteractive@gmail.com>
 sentence=Arduino library for eliminating noise in analogRead inputs without decreasing responsiveness

--- a/src/ResponsiveAnalogRead.cpp
+++ b/src/ResponsiveAnalogRead.cpp
@@ -44,8 +44,9 @@ void ResponsiveAnalogRead::update()
   this->update(rawValue);
 }
 
-void ResponsiveAnalogRead::update(int rawValue)
+void ResponsiveAnalogRead::update(int rawValueRead)
 {
+  rawValue = rawValueRead;
   prevResponsiveValue = responsiveValue;
   responsiveValue = getResponsiveValue(rawValue);
   responsiveValueHasChanged = responsiveValue != prevResponsiveValue;

--- a/src/ResponsiveAnalogRead.h
+++ b/src/ResponsiveAnalogRead.h
@@ -51,7 +51,7 @@ class ResponsiveAnalogRead
     inline bool hasChanged() { return responsiveValueHasChanged; } // returns true if the responsive value has changed during the last update
     inline bool isSleeping() { return sleeping; } // returns true if the algorithm is currently in sleeping mode
     void update(); // updates the value by performing an analogRead() and calculating a responsive value based off it
-    void update(int rawValue); // updates the value accepting a value and calculating a responsive value based off it
+    void update(int rawValueRead); // updates the value accepting a value and calculating a responsive value based off it
 
     void setSnapMultiplier(float newMultiplier);
     inline void enableSleep() { sleepEnable = true; }


### PR DESCRIPTION
- Fix bug where calls to `update(rawValue)` (not `update()`) wouldn't set `rawValue`, so `rawValue` remained at 0.
- Fix keyword separator
- Host readme image on github